### PR TITLE
fix network abort when the project is scaled down

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -715,7 +715,6 @@ int cloudsync_network_send_changes_internal (sqlite3_context *context, int argc,
     cloudsync_memory_free(blob);
     if (sent == false) {
         network_result_to_sqlite_error(context, res, "cloudsync_network_send_changes unable to upload BLOB changes to remote host.");
-        network_result_cleanup(&res);
         return SQLITE_ERROR;
     }
     
@@ -729,7 +728,6 @@ int cloudsync_network_send_changes_internal (sqlite3_context *context, int argc,
     res = network_receive_buffer(data, data->upload_endpoint, data->authentication, true, true, json_payload, CLOUDSYNC_HEADER_SQLITECLOUD);
     if (res.code != CLOUDSYNC_NETWORK_OK) {
         network_result_to_sqlite_error(context, res, "cloudsync_network_send_changes unable to notify BLOB upload to remote host.");
-        network_result_cleanup(&res);
         return SQLITE_ERROR;
     }
     


### PR DESCRIPTION
The bug was reported by @damlayildiz to be present only in Android.
In reality the bug is also in other platforms, since this code wasn't platform related.

The bug was introduced by this [commit](https://github.com/sqliteai/sqlite-sync/commit/e7d6a3eabbdc40f98dc601e2510d79def3eebe34#diff-5db0914fb2aeac80a2dd975e05ef91ee9367ea525c46c3ce128d1670b5eca4aa).

Basically before returning SQLITE_ERROR in case of an error the `network_result_cleanup` function was called 2 times: the first time inside `cloudsync_network_send_changes_internal` and the second time in `network_result_to_sqlite_error` causing a double cleanup issue.

Here's a before and after the fix:

**Android**
Before:
`
sqlite> .load ./cloudsync0_8_59
sqlite> SELECT cloudsync_version();
0.8.59
sqlite> CREATE TABLE IF NOT EXISTS test_table (id TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL DEFAULT '', created_at TEXT DEFAULT CURRENT_TIMESTAMP);
sqlite> .tables
test_table
sqlite> SELECT cloudsync_init('test_table');
019ba3fcb7807fb0a25a9bfbaf81371a
sqlite> INSERT INTO test_table (id, value) VALUES (cloudsync_uuid(), 'test1'), (cloudsync_uuid(), 'test2');
sqlite> SELECT * FROM test_table;
019ba3fc-cb71-7d61-8888-2c7afeec91fe|test1|2026-01-09 18:20:12
019ba3fc-cb71-74a8-8ead-f587682a2ef1|test2|2026-01-09 18:20:12
sqlite> SELECT cloudsync_network_init(CONNECTION_STRING);
0
sqlite> SELECT cloudsync_network_set_apikey(API_KEY);
0
sqlite> SELECT cloudsync_network_sync();
Aborted 
134|emu64a:/data/local/tmp $ 
`

After
`
sqlite> .load ./cloudsync.so
sqlite> SELECT cloudsync_version();CREATE TABLE IF NOT EXISTS test_table (id TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL DEFAULT '', created_at TEXT DEFAULT CURRENT_TIMESTAMP);SELECT cloudsync_init('test_table');INSERT INTO test_table (id, value) VALUES (cloudsync_uuid(), 'test1'), (cloudsync_uuid(), 'test2');SELECT cloudsync_network_init(CONNECTION_STRING);SELECT cloudsync_network_set_apikey(API_KEY);SELECT * FROM test_table;
0.8.59
019ba414944a76e6873861d820c968d5
0
0
019ba414-9459-728a-bffa-5e115763d814|test1|2026-01-09 18:46:10
019ba414-9459-7b14-a5c8-ff9697f9f9e7|test2|2026-01-09 18:46:10
sqlite> SELECT cloudsync_network_sync();
Runtime error: cloudsync_network_send_changes unable to upload BLOB changes to remote host.
`

**MacOS**
Before:
`
sqlite> .load ./cloudsync
sqlite> SELECT cloudsync_version();CREATE TABLE IF NOT EXISTS test_table (id TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL DEFAULT '', created_at TEXT DEFAULT CURRENT_TIMESTAMP);SELECT cloudsync_init('test_table');INSERT INTO test_table (id, value) VALUES (cloudsync_uuid(), 'test1'), (cloudsync_uuid(), 'test2');SELECT cloudsync_network_init(CONNECTION_STRING);SELECT cloudsync_network_set_apikey(API_KEY);SELECT * FROM test_table;
0.8.59
019ba4171dc2715eb3ff741fa87167ac
0
0
019ba417-1dc5-7d6e-af76-401c8b5573b4|test1|2026-01-09 18:48:57
019ba417-1dc5-7bac-8631-79bee62e6ecb|test2|2026-01-09 18:48:57
sqlite> SELECT cloudsync_network_sync();
sqlite3(87025,0x1fc646c40) malloc: *** error for object 0xc7e838200: pointer being freed was not allocated
sqlite3(87025,0x1fc646c40) malloc: *** set a breakpoint in malloc_error_break to debug
zsh: abort      sqlite3
`

After:
`
sqlite> .load ./cloudsync
sqlite> SELECT cloudsync_version();CREATE TABLE IF NOT EXISTS test_table (id TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL DEFAULT '', created_at TEXT DEFAULT CURRENT_TIMESTAMP);SELECT cloudsync_init('test_table');INSERT INTO test_table (id, value) VALUES (cloudsync_uuid(), 'test1'), (cloudsync_uuid(), 'test2');SELECT cloudsync_network_init(CONNECTION_STRING);SELECT cloudsync_network_set_apikey(API_KEY);SELECT * FROM test_table;
0.8.59
019ba4164827784f86f8dd450deb9cbb
0
0
019ba416-482a-78ec-9ef2-40fbf566242c|test1|2026-01-09 18:48:02
019ba416-482a-70bc-acb2-72c8edcdc76c|test2|2026-01-09 18:48:02
sqlite> SELECT cloudsync_network_sync();
Runtime error: cloudsync_network_send_changes unable to upload BLOB changes to remote host.
`