### PR TITLE
fix: WASM crash in cloudsync_set_column on tables with existing rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.0.16] - 2026-04-16
+
+### Fixed
+
+- **WASM crash in `cloudsync_set_column` on existing rows**: Calling `cloudsync_set_column(table, col, 'lww', 'block')` on a table with pre-existing rows crashed the WASM build with a `RuntimeError: function signature mismatch` as soon as the block-index migration tried to allocate memory. `block_init_allocator` was casting `cloudsync_memory_alloc` (a `uint64_t size` function) directly to the fractional-indexing allocator's `void *(*)(size_t)` slot. The cast is a no-op on native platforms where `size_t` is 64-bit, but WASM's `call_indirect` enforces strict type checking — the function is registered as `(i64) -> i32` and called as `(i32) -> i32`, triggering an immediate runtime error. A thin `fi_malloc_wrapper` (mirroring the existing `fi_calloc_wrapper`) now bridges the signatures. Native builds are unaffected.
+
 ## [1.0.15] - 2026-04-16
 
 ### Fixed

--- a/src/block.c
+++ b/src/block.c
@@ -127,6 +127,12 @@ block_list_t *block_split(const char *text, const char *delimiter) {
 
 // MARK: - Fractional indexing (via fractional-indexing submodule) -
 
+// Wrapper for malloc: fractional_indexing expects size_t (32-bit on WASM) but cloudsync_memory_alloc takes uint64_t.
+// A direct cast passes strict call_indirect type checking in WASM and triggers a RuntimeError.
+static void *fi_malloc_wrapper(size_t size) {
+    return cloudsync_memory_alloc((uint64_t)size);
+}
+
 // Wrapper for calloc: fractional_indexing expects (count, size) but cloudsync_memory_zeroalloc takes a single size.
 static void *fi_calloc_wrapper(size_t count, size_t size) {
     return cloudsync_memory_zeroalloc((uint64_t)(count * size));
@@ -134,7 +140,7 @@ static void *fi_calloc_wrapper(size_t count, size_t size) {
 
 void block_init_allocator(void) {
     fractional_indexing_allocator alloc = {
-        .malloc = (void *(*)(size_t))cloudsync_memory_alloc,
+        .malloc = fi_malloc_wrapper,
         .calloc = fi_calloc_wrapper,
         .free   = cloudsync_memory_free
     };

--- a/src/cloudsync.h
+++ b/src/cloudsync.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define CLOUDSYNC_VERSION                       "1.0.15"
+#define CLOUDSYNC_VERSION                       "1.0.16"
 #define CLOUDSYNC_MAX_TABLENAME_LEN             512
 
 #define CLOUDSYNC_VALUE_NOTSET                  -1


### PR DESCRIPTION
Summary

Calling cloudsync_set_column(table, col, 'algo', 'block') on a table with pre-existing rows crashes the WASM build with RuntimeError: function signature mismatch as soon as the block-index
migration tries to allocate memory. Native builds are unaffected.

Root cause

src/block.c:137 cast cloudsync_memory_alloc directly into the fractional-indexing allocator slot:

.malloc = (void *(*)(size_t))cloudsync_memory_alloc,

- cloudsync_memory_alloc → dbmem_alloc(uint64_t)
- fractional_indexing_allocator.malloc is void *(*)(size_t)

On native platforms size_t is 64-bit, so the cast is a no-op. In WASM size_t is 32-bit, and call_indirect enforces strict type checking: the function is registered in the table as (i64) -> i32 but
 called as (i32) -> i32 — immediate runtime error. Documented Emscripten pitfall: https://emscripten.org/docs/porting/guidelines/function_pointer_issues.html

Fix

Bridge through a thin fi_malloc_wrapper, mirroring the existing fi_calloc_wrapper pattern already used for the calloc slot. free is already fine (dbmem_free(void*) matches the expected signature
on every target).

Changes

- src/block.c — new fi_malloc_wrapper, used in block_init_allocator
- src/cloudsync.h — CLOUDSYNC_VERSION → 1.0.16
- CHANGELOG.md — 1.0.16 entry

Test plan

- make clean && make && make unittest — all tests pass (Block LWW suite + Memory Leaks Check)
- make postgres-docker-run-test — 0 failures
- Verify in a WASM build: cloudsync_set_column on a table with existing rows no longer raises function signature mismatch
- Smoke-test block-level LWW roundtrip in the WASM environment